### PR TITLE
超过maxIdleTime的连接没有close导致established状态的连接持续增长

### DIFF
--- a/src/AbstractPool.php
+++ b/src/AbstractPool.php
@@ -275,6 +275,7 @@ abstract class AbstractPool implements PoolInterface
             // Out of `maxIdleTime`
             if ($time - $lastTime > $this->maxIdleTime) {
                 $this->count--;
+                $connection->close();
                 continue;
             }
 


### PR DESCRIPTION
超过maxIdleTime的连接没有close导致established状态的连接持续增长。

1、补充：我们的应用，线上使用已经复写了基类。

2、已经模拟了redis server端的close不会导致增加这句报异常，无需catch异常；

3、文档可以提醒使用swoft的开发者：
使用redis，option的persistent建议配置false，否则php扩展的实现连接不会被close